### PR TITLE
add file browser for task's type as  file

### DIFF
--- a/assets/components/scheduler/js/mgr/combos.js
+++ b/assets/components/scheduler/js/mgr/combos.js
@@ -1,78 +1,151 @@
-Scheduler.combo.ClassKeyList = function(config) {
-    config = config || {};
+Scheduler.combo.ClassKeyList = function (config) {
+    config = config || {}
     Ext.applyIf(config, {
         name: 'class_key'
-		,hiddenName: 'class_key'
-		,displayField: 'value'
-		,valueField: 'key'
-		,fields: ['key','value']
-		,forceSelection: true
-		,typeAhead: false
-		,editable: false
-		,allowBlank: false
-		,autocomplete: false
-		,url: Scheduler.config.connectorUrl
-		,baseParams: {
+        , hiddenName: 'class_key'
+        , displayField: 'value'
+        , valueField: 'key'
+        , fields: ['key', 'value']
+        , forceSelection: true
+        , typeAhead: false
+        , editable: false
+        , allowBlank: false
+        , autocomplete: false
+        , url: Scheduler.config.connectorUrl
+        , baseParams: {
             action: 'mgr/common/classes/getlist'
-			,combo: true
+            , combo: true
         }
-    });
-    Scheduler.combo.ClassKeyList.superclass.constructor.call(this, config);
-};
-Ext.extend(Scheduler.combo.ClassKeyList, MODx.combo.ComboBox);
-Ext.reg('scheduler-combo-classkeylist', Scheduler.combo.ClassKeyList);
+    })
+    Scheduler.combo.ClassKeyList.superclass.constructor.call(this, config)
+}
+Ext.extend(Scheduler.combo.ClassKeyList, MODx.combo.ComboBox)
+Ext.reg('scheduler-combo-classkeylist', Scheduler.combo.ClassKeyList)
 
-Scheduler.combo.SnippetList = function(config) {
-    config = config || {};
+Scheduler.combo.SnippetList = function (config) {
+    config = config || {}
     Ext.applyIf(config, {
         name: 'snippet'
-		,hiddenName: 'snippet'
-		,displayField: 'name'
-		,valueField: 'id'
-		,fields: ['id','name']
-		,forceSelection: true
-		,typeAhead: true
-        ,minChars: 1
-		,editable: true
-		,allowBlank: false
-		,autocomplete: true
-        ,pageSize: 10
-		,url: Scheduler.config.connectorUrl
-		,baseParams: {
+        , hiddenName: 'snippet'
+        , displayField: 'name'
+        , valueField: 'id'
+        , fields: ['id', 'name']
+        , forceSelection: true
+        , typeAhead: true
+        , minChars: 1
+        , editable: true
+        , allowBlank: false
+        , autocomplete: true
+        , pageSize: 10
+        , url: Scheduler.config.connectorUrl
+        , baseParams: {
             action: 'mgr/common/snippets/getlist'
-			,combo: true
+            , combo: true
         }
-    });
-    Scheduler.combo.SnippetList.superclass.constructor.call(this, config);
-};
-Ext.extend(Scheduler.combo.SnippetList, MODx.combo.ComboBox);
-Ext.reg('scheduler-combo-snippets', Scheduler.combo.SnippetList);
+    })
+    Scheduler.combo.SnippetList.superclass.constructor.call(this, config)
+}
+Ext.extend(Scheduler.combo.SnippetList, MODx.combo.ComboBox)
+Ext.reg('scheduler-combo-snippets', Scheduler.combo.SnippetList)
 
-Scheduler.combo.TaskList = function(config) {
-    config = config || {};
+Scheduler.combo.TaskList = function (config) {
+    config = config || {}
     Ext.applyIf(config, {
         name: 'task'
-		,hiddenName: 'task'
-		,displayField: 'task_string'
-		,valueField: 'id'
-		,fields: ['id','reference','namespace', 'task_string']
-		,forceSelection: true
-		,typeAhead: true
-        ,minChars: 1
-		,editable: true
-		,allowBlank: false
-		,autocomplete: true
-        ,pageSize: 10
-		,url: Scheduler.config.connectorUrl
-		,baseParams: {
+        , hiddenName: 'task'
+        , displayField: 'task_string'
+        , valueField: 'id'
+        , fields: ['id', 'reference', 'namespace', 'task_string']
+        , forceSelection: true
+        , typeAhead: true
+        , minChars: 1
+        , editable: true
+        , allowBlank: false
+        , autocomplete: true
+        , pageSize: 10
+        , url: Scheduler.config.connectorUrl
+        , baseParams: {
             action: 'mgr/tasks/getlist'
-			,combo: true
+            , combo: true
         }
-        ,tpl: new Ext.XTemplate(
+        , tpl: new Ext.XTemplate(
             '<tpl for="."><div class="x-combo-list-item">{namespace} : {reference}</div></tpl>'
         )
-    });
-    Scheduler.combo.TaskList.superclass.constructor.call(this, config);
-};
-Ext.extend(Scheduler.combo.TaskList, MODx.combo.ComboBox);
-Ext.reg('scheduler-combo-tasklist', Scheduler.combo.TaskList);
+    })
+    Scheduler.combo.TaskList.superclass.constructor.call(this, config)
+}
+Ext.extend(Scheduler.combo.TaskList, MODx.combo.ComboBox)
+Ext.reg('scheduler-combo-tasklist', Scheduler.combo.TaskList)
+
+Scheduler.combo.Browser = function (config) {
+    config = config || {}
+
+    if (config.length != 0 && config.openTo != undefined) {
+        if (!/^\//.test(config.openTo)) {
+            config.openTo = '/' + config.openTo
+        }
+        if (!/$\//.test(config.openTo)) {
+            var tmp = config.openTo.split('/')
+            delete tmp[tmp.length - 1]
+            tmp = tmp.join('/')
+            config.openTo = tmp.substr(1)
+        }
+    }
+
+    Ext.applyIf(config, {
+        width: 300,
+        triggerAction: 'all'
+    })
+    Scheduler.combo.Browser.superclass.constructor.call(this, config)
+    this.config = config
+}
+Ext.extend(Scheduler.combo.Browser, Ext.form.TriggerField, {
+    browser: null,
+
+    onTriggerClick: function () {
+        if (this.disabled) {
+            return false
+        }
+        const browser = MODx.load({
+            xtype: 'modx-browser',
+            id: Ext.id(),
+            multiple: true,
+            source: this.config.source || MODx.config['default_media_source'],
+            rootVisible: this.config.rootVisible || false,
+            allowedFileTypes: this.config.allowedFileTypes || '',
+            wctx: this.config.wctx || 'web',
+            openTo: this.config.openTo || '',
+            rootId: this.config.rootId || '/',
+            hideSourceCombo: this.config.hideSourceCombo || false,
+            hideFiles: this.config.hideFiles || true,
+            listeners: {
+                select: {
+                    fn: function (data) {
+                        this.setValue(data.fullRelativeUrl)
+                        this.fireEvent('select', data)
+                    }, scope: this
+                }
+            },
+        })
+        browser.win.buttons[0].on('disable', function () {
+            this.enable()
+        })
+        browser.win.tree.on('click', function (n) {
+            this.setValue(this.getPath(n))
+        }, this)
+        browser.win.tree.on('dblclick', function (n) {
+            this.setValue(this.getPath(n))
+            browser.hide()
+        }, this)
+        browser.show()
+    },
+
+    getPath: function (n) {
+        if (n.id === '/') {
+            return ''
+        }
+
+        return n.attributes.path + '/'
+    }
+})
+Ext.reg('scheduler-combo-browser', Scheduler.combo.Browser)

--- a/assets/components/scheduler/js/mgr/widgets/windows.tasks.js
+++ b/assets/components/scheduler/js/mgr/widgets/windows.tasks.js
@@ -1,173 +1,186 @@
-Scheduler.window.CreateUpdateTask = function(config) {
-	config = config || {};
-    this.ident = config.ident || Ext.id();
+Scheduler.window.CreateUpdateTask = function (config) {
+    config = config || {}
+    this.ident = config.ident || Ext.id()
 
-	Ext.applyIf(config,{
-		title: _('scheduler.task_create')
-		,url: Scheduler.config.connectorUrl
-		,baseParams: {
-			action: ((config.isUpdate) ? 'mgr/tasks/update' : 'mgr/tasks/create')
-		}
-        ,width: 600
-        ,modal: true
-        ,defaults: { border: false }
-        ,fields: [{
-            xtype: 'hidden'
-            ,name: 'id'
-        },{
-            layout: 'column'
-            ,border: false
-            ,items: [{
-                layout: 'form'
-                ,columnWidth: .5
-                ,items: [{
-                    xtype: 'textfield'
-                    ,name: 'reference'
-                    ,fieldLabel: _('scheduler.reference')
-                    ,anchor: '100%'
-                    ,allowBlank: false
-                },{
-                    xtype: 'scheduler-combo-classkeylist'
-                    ,name: 'class_key'
-                    ,hiddenName: 'class_key'
-                    ,fieldLabel: _('scheduler.class_key')
-                    ,anchor: '100%'
-                    ,allowBlank: false
-                    ,value: config.record.class_key || 'sFileTask'
-                    ,listeners: {
-                        'select': { fn: function(cb,rec,idx) {
-                            var val = cb.getValue();
-                            this.showHideContents(val);
-                        } ,scope: this }
-                    }
-                },{
-                    xtype: 'modx-combo-namespace'
-                    ,name: 'namespace'
-                    ,hiddenName: 'namespace'
-                    ,fieldLabel: _('scheduler.namespace')
-                    ,anchor: '100%'
-                    ,allowBlank: false
-                }]
-            },{
-                layout: 'form'
-                ,columnWidth: .5
-                ,items: [{
-                    xtype: 'textarea'
-                    ,name: 'description'
-                    ,fieldLabel: _('scheduler.description')
-                    ,anchor: '100%'
-                    ,height: 145
-                }]
-            }]
-        },{
-            id: 'scheduler-file-content-fields-'+this.ident
-            ,layout: 'form'
-            ,items: [{
-                xtype: 'textarea'
-                ,name: 'file-content'
-                ,id: 'scheduler-task-file-content'+this.ident
-                ,fieldLabel: _('scheduler.content.file')
-                ,description: MODx.expandHelp ? '' : _('scheduler.content.file_desc')
-                ,anchor: '100%'
-                ,value: config.record.content || ''
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'scheduler-task-file-content'
-                ,html: _('scheduler.content.file_desc')
-                ,cls: 'desc-under'
-            }]
-        },{
-            id: 'scheduler-snippet-content-fields-'+this.ident
-            ,layout: 'form'
-            ,items: [{
-                xtype: 'scheduler-combo-snippets'
-                ,name: 'snippet-content'
-                ,hiddenName: 'snippet-content'
-                ,id: 'scheduler-task-snippet-content'+this.ident
-                ,fieldLabel: _('scheduler.content.snippet')
-                ,description: MODx.expandHelp ? '' : _('scheduler.content.snippet_desc')
-                ,anchor: '100%'
-                ,value: config.record.content || ''
-                ,allowBlank: true
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'scheduler-task-snippet-content'
-                ,html: _('scheduler.content.snippet_desc')
-                ,cls: 'desc-under'
-            }]
-        },{
-            id: 'scheduler-processor-content-fields-'+this.ident
-            ,layout: 'form'
-            ,items: [{
-                xtype: 'textfield'
-                ,name: 'processor-content'
-                ,id: 'scheduler-task-processor-content'+this.ident
-                ,fieldLabel: _('scheduler.content.processor')
-                ,description: MODx.expandHelp ? '' : _('scheduler.content.processor_desc')
-                ,anchor: '100%'
-                ,value: config.record.content || ''
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'scheduler-task-processor-content'
-                ,html: _('scheduler.content.processor_desc')
-                ,cls: 'desc-under'
-            }]
-        }]
-        ,listeners: {
-            'afterrender': { fn: this.initDisplays ,scope: this }
+    Ext.applyIf(config, {
+        title: _('scheduler.task_create')
+        , url: Scheduler.config.connectorUrl
+        , baseParams: {
+            action: ((config.isUpdate) ? 'mgr/tasks/update' : 'mgr/tasks/create')
         }
-	});
-	Scheduler.window.CreateUpdateTask.superclass.constructor.call(this,config);
+        , width: 600
+        , modal: true
+        , defaults: { border: false }
+        , fields: [
+            {
+                xtype: 'hidden'
+                , name: 'id'
+            },
+            {
+                layout: 'column'
+                , border: false
+                , items: [{
+                    layout: 'form'
+                    , columnWidth: .5
+                    , items: [{
+                        xtype: 'textfield'
+                        , name: 'reference'
+                        , fieldLabel: _('scheduler.reference')
+                        , anchor: '100%'
+                        , allowBlank: false
+                    }, {
+                        xtype: 'scheduler-combo-classkeylist'
+                        , name: 'class_key'
+                        , hiddenName: 'class_key'
+                        , fieldLabel: _('scheduler.class_key')
+                        , anchor: '100%'
+                        , allowBlank: false
+                        , value: config.record.class_key || 'sFileTask'
+                        , listeners: {
+                            'select': {
+                                fn: function (cb, rec, idx) {
+                                    var val = cb.getValue()
+                                    this.showHideContents(val)
+                                }, scope: this
+                            }
+                        }
+                    }, {
+                        xtype: 'modx-combo-namespace'
+                        , name: 'namespace'
+                        , hiddenName: 'namespace'
+                        , fieldLabel: _('scheduler.namespace')
+                        , anchor: '100%'
+                        , allowBlank: false
+                    }]
+                }, {
+                    layout: 'form'
+                    , columnWidth: .5
+                    , items: [{
+                        xtype: 'textarea'
+                        , name: 'description'
+                        , fieldLabel: _('scheduler.description')
+                        , anchor: '100%'
+                        , height: 145
+                    }]
+                }]
+            },
+            {
+                id: 'scheduler-file-content-fields-' + this.ident
+                , layout: 'form'
+                , items: [
+                    {
+                        xtype: 'scheduler-combo-browser',
+                        fieldLabel: _('scheduler.content.file'),
+                        name: 'file-content',
+                        anchor: '99%',
+                        id: 'scheduler-task-file-content' + this.ident,
+                        description: MODx.expandHelp ? '' : _('scheduler.content.file_desc'),
+                        triggerClass: 'x-form-image-trigger',
+                        allowedFileTypes: 'php',
+                        value: config.record.content || ''
+                    },
+                    {
+                        xtype: MODx.expandHelp ? 'label' : 'hidden'
+                        , forId: 'scheduler-task-file-content'
+                        , html: _('scheduler.content.file_desc')
+                        , cls: 'desc-under'
+                    }
+                ]
+            },
+            {
+                id: 'scheduler-snippet-content-fields-' + this.ident
+                , layout: 'form'
+                , items: [{
+                    xtype: 'scheduler-combo-snippets'
+                    , name: 'snippet-content'
+                    , hiddenName: 'snippet-content'
+                    , id: 'scheduler-task-snippet-content' + this.ident
+                    , fieldLabel: _('scheduler.content.snippet')
+                    , description: MODx.expandHelp ? '' : _('scheduler.content.snippet_desc')
+                    , anchor: '100%'
+                    , value: config.record.content || ''
+                    , allowBlank: true
+                }, {
+                    xtype: MODx.expandHelp ? 'label' : 'hidden'
+                    , forId: 'scheduler-task-snippet-content'
+                    , html: _('scheduler.content.snippet_desc')
+                    , cls: 'desc-under'
+                }]
+            },
+            {
+                id: 'scheduler-processor-content-fields-' + this.ident
+                , layout: 'form'
+                , items: [{
+                    xtype: 'textfield'
+                    , name: 'processor-content'
+                    , id: 'scheduler-task-processor-content' + this.ident
+                    , fieldLabel: _('scheduler.content.processor')
+                    , description: MODx.expandHelp ? '' : _('scheduler.content.processor_desc')
+                    , anchor: '100%'
+                    , value: config.record.content || ''
+                }, {
+                    xtype: MODx.expandHelp ? 'label' : 'hidden'
+                    , forId: 'scheduler-task-processor-content'
+                    , html: _('scheduler.content.processor_desc')
+                    , cls: 'desc-under'
+                }]
+            }
+        ]
+        , listeners: {
+            'afterrender': { fn: this.initDisplays, scope: this }
+        }
+    })
+    Scheduler.window.CreateUpdateTask.superclass.constructor.call(this, config)
 
-    this.on('show', function() {
-        this.fileCntElm = Ext.getCmp('scheduler-file-content-fields-'+this.ident).getEl();
-        this.snipCntElm = Ext.getCmp('scheduler-snippet-content-fields-'+this.ident).getEl();
-        this.procCntElm = Ext.getCmp('scheduler-processor-content-fields-'+this.ident).getEl();
+    this.on('show', function () {
+        this.fileCntElm = Ext.getCmp('scheduler-file-content-fields-' + this.ident).getEl()
+        this.snipCntElm = Ext.getCmp('scheduler-snippet-content-fields-' + this.ident).getEl()
+        this.procCntElm = Ext.getCmp('scheduler-processor-content-fields-' + this.ident).getEl()
 
-        this.fileCntElm.setVisibilityMode(Ext.Element.DISPLAY);
-        this.fileCntElm.setVisible(true);
-        this.snipCntElm.setVisibilityMode(Ext.Element.DISPLAY);
-        this.snipCntElm.setVisible(false);
-        this.procCntElm.setVisibilityMode(Ext.Element.DISPLAY);
-        this.procCntElm.setVisible(false);
+        this.fileCntElm.setVisibilityMode(Ext.Element.DISPLAY)
+        this.fileCntElm.setVisible(true)
+        this.snipCntElm.setVisibilityMode(Ext.Element.DISPLAY)
+        this.snipCntElm.setVisible(false)
+        this.procCntElm.setVisibilityMode(Ext.Element.DISPLAY)
+        this.procCntElm.setVisible(false)
 
-        this.showHideContents(( config.record.class_key || 'sFileTask' ));
-    });
-};
+        this.showHideContents((config.record.class_key || 'sFileTask'))
+    })
+}
 Ext.extend(Scheduler.window.CreateUpdateTask, MODx.Window, {
-    showHideContents: function(type) {
-        switch(type) {
+    showHideContents: function (type) {
+        switch (type) {
             case 'sFileTask':
-                this.fileCntElm.setVisible(true);
-                this.fileCntElm.slideIn();
+                this.fileCntElm.setVisible(true)
+                this.fileCntElm.slideIn()
 
-                this.snipCntElm.slideOut();
-                this.snipCntElm.setVisible(false);
+                this.snipCntElm.slideOut()
+                this.snipCntElm.setVisible(false)
 
-                this.procCntElm.slideOut();
-                this.procCntElm.setVisible(false);
-            break;
+                this.procCntElm.slideOut()
+                this.procCntElm.setVisible(false)
+                break
             case 'sSnippetTask':
-                this.fileCntElm.slideOut();
-                this.fileCntElm.setVisible(false);
+                this.fileCntElm.slideOut()
+                this.fileCntElm.setVisible(false)
 
-                this.snipCntElm.setVisible(true);
-                this.snipCntElm.slideIn();
+                this.snipCntElm.setVisible(true)
+                this.snipCntElm.slideIn()
 
-                this.procCntElm.slideOut();
-                this.procCntElm.setVisible(false);
-            break;
+                this.procCntElm.slideOut()
+                this.procCntElm.setVisible(false)
+                break
             case 'sProcessorTask':
-                this.fileCntElm.slideOut();
-                this.fileCntElm.setVisible(false);
+                this.fileCntElm.slideOut()
+                this.fileCntElm.setVisible(false)
 
-                this.snipCntElm.slideOut();
-                this.snipCntElm.setVisible(false);
+                this.snipCntElm.slideOut()
+                this.snipCntElm.setVisible(false)
 
-                this.procCntElm.setVisible(true);
-                this.procCntElm.slideIn();
-            break;
+                this.procCntElm.setVisible(true)
+                this.procCntElm.slideIn()
+                break
         }
     }
-});
-Ext.reg('scheduler-window-task-createupdate', Scheduler.window.CreateUpdateTask);
+})
+Ext.reg('scheduler-window-task-createupdate', Scheduler.window.CreateUpdateTask)


### PR DESCRIPTION
### Что оно делает?

Добавлен визуальный выбор файла-задания для случаев, когда задание задается с типом Файл.

### Зачем это нужно?
Раньше путь к файлу нужно было писать руками. Легко ошибиться. 

