### PR TITLE
added possibility to specify task_key when creating a task programmatically

### DIFF
--- a/core/components/scheduler/model/scheduler/stask.class.php
+++ b/core/components/scheduler/model/scheduler/stask.class.php
@@ -11,13 +11,14 @@ class sTask extends xPDOSimpleObject
      * @param array $data
      * @return false|sTaskRun
      */
-    public function schedule($when, array $data = array()) {
+    public function schedule($when, array $data = array(), string $task_key = '') {
 
         /** @var sTaskRun $run */
         $run = $this->xpdo->newObject('sTaskRun');
         $run->fromArray(array(
             'task' => $this->get('id'),
             'data' => $data,
+            'task_key' => $task_key,
         ));
         $run->setTiming($when);
 


### PR DESCRIPTION
```
<?php
// Load the Scheduler service class
$path = $modx->getOption('scheduler.core_path', null, $modx->getOption('core_path') . 'components/scheduler/');
$scheduler = $modx->getService('scheduler', 'Scheduler', $path . 'model/scheduler/');
if (!($scheduler instanceof Scheduler)) {
    return 'Oops, could not get Scheduler service.';
}

/**
 * Get the task with reference "dosomething" in the "mycmp" namespace.
 * This task should have been added earlier via a build or the component.
 */
$task = $scheduler->getTask('mycmp', 'dosomething');
if ($task instanceof sTask) {
    // Schedule a run in 10 minutes from now
    // We're passing along an array of data; in this case a client ID.
    $task->schedule('+10 minutes', array(
        'client' => 15
    ),
    'any task key' // new feature
);
}
```